### PR TITLE
Added indentation guide for rescue blocks to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 General rules follow; but we also have language-specific guides for [Ruby](/lang/Ruby.md), [CoffeeScript](/lang/CoffeeScript.md), and [HTML/CSS](/lang/CSS.md).
 
 
+
 ## White Space
 
  - Use soft-tabs with a two-space indent
@@ -57,6 +58,8 @@ General rules follow; but we also have language-specific guides for [Ruby](/lang
       end
     end
     ```
+
+
 
 ## Commits
 

--- a/lang/Ruby.md
+++ b/lang/Ruby.md
@@ -104,6 +104,16 @@ We've adapted this from [GitHub's Ruby style guide](https://github.com/styleguid
     end
     ```
 
+ - `rescue` blocks should be outdented from the method block
+
+    ```ruby
+    def some_method_with_rescue
+      do_something_that_could_throw_exception!
+    rescue
+      i_did_something_funny
+    end
+    ```
+
 
 
 ## Parentheses


### PR DESCRIPTION
```ruby
def some_method_with_rescue
  do_something_that_could_throw_exception!
rescue
  i_did_something_funny
end
```